### PR TITLE
#16 remove event from the event list if it was triggered

### DIFF
--- a/src/main/java/com/corporate/hellscape/Hellscape.java
+++ b/src/main/java/com/corporate/hellscape/Hellscape.java
@@ -36,6 +36,7 @@ public class Hellscape {
 
     private Collection<Event> _eventList = new ArrayList<Event>();
     private Collection<Event> _pendingNewEvents = new ArrayList<Event>();
+    private Collection<Event> _pendingDeletedEvents = new ArrayList<Event>();
     private EventSpawner _eventSpawner = new EventSpawner();
 
     private Hellscape() {
@@ -48,20 +49,19 @@ public class Hellscape {
         //TODO: Currently using StatusEvent as a concrete class so that things will compile
         //      For issue #6, replace this with your concrete class that *implements* StatusEvent
         _eventList.add(new StatusEventHungerLow());
-
     }
 
     //NOTE: When implementing #6, get character from here
     public Character getCharacter() {
+
         return _character;
     };
 
     //NOTE: When implementing #7, get time from here
     public LocalDateTime getGameTime() {
+
         return _gameTime;
     };
-
-
 
     //Add an event to the pending new list for later insertion
     //into the general events list
@@ -70,23 +70,41 @@ public class Hellscape {
         _pendingNewEvents.add(event);
     }
 
+    //Add an event to a list to be deleted at the end of
+    //a simulation iteration
+    public void _markEventForDeletion(Event event) {
+
+        _pendingDeletedEvents.add(event);
+    }
+
     //Add any events that were added to the pending new list
     //to the event list *after* we're done iterating the event list
     private void _addNewlyCreatedEvents() {
 
         _eventList.addAll(_pendingNewEvents);
+        _pendingNewEvents.clear();
     }
 
+    //Remove any events that were detected retired during simulation
+    private void _removeDeletedEvents() {
+
+        _eventList.removeAll(_pendingDeletedEvents);
+        _pendingDeletedEvents.clear();
+    }
 
     //Simulate a single second of game time
     private void SimulateOnce() {
 
-        for(Event event : _eventList) 
+        for(Event event : _eventList) {
+
             event.process(this);
+
+            if(event.isRetired())
+                _markEventForDeletion(event);
+        }
 
         while(true) {
 
-            //TODO: Implement random events in #5
             Event newEvent = _eventSpawner.getPendingEvent(this);
 
             if(newEvent == null)
@@ -95,10 +113,10 @@ public class Hellscape {
             _eventList.add(newEvent);
         }
 
-
         //NOTE: We do things this way because Java will give you a runtime
         //      exception if you try to modify the thing being iterated
         //      *while* it's being iterated over
+        _removeDeletedEvents();
         _addNewlyCreatedEvents();
 
         _gameTime = _gameTime.plusSeconds(1);

--- a/src/main/java/com/corporate/hellscape/events/Event.java
+++ b/src/main/java/com/corporate/hellscape/events/Event.java
@@ -3,6 +3,8 @@ package com.corporate.hellscape.events;
 import com.corporate.hellscape.Hellscape;
 
 public abstract class Event {
+
+    private boolean _isRetired = false;
     
     public void process(Hellscape hellscape) {
 
@@ -10,8 +12,14 @@ public abstract class Event {
             return;
 
         triggerAction(hellscape);
+        _isRetired = true;
     }
 
     public abstract boolean isTriggered(Hellscape hellscape);
     protected abstract void triggerAction(Hellscape hellscape);
+    
+    public boolean isRetired() {
+
+        return _isRetired;
+    }
 }

--- a/src/main/java/com/corporate/hellscape/events/TimedEventImp.java
+++ b/src/main/java/com/corporate/hellscape/events/TimedEventImp.java
@@ -11,6 +11,7 @@ public class TimedEventImp extends TimedEvent {
 
     protected void triggerAction(Hellscape hellscape) {
 
-        throw new UnsupportedOperationException("TimedEventImp triggerd after 10 game seconds");
+        //Using this as an example to show that event retirement is working properly
+        System.out.println("This timed event should only trigger once");
     }
 }


### PR DESCRIPTION
- Added a getter to the base `Event` class that returns whether the event is retired
- Updated base `Event` class to mark itself retired after it is triggered and it has run its action
- Added a list to `Hellscape` to hold events that were marked retired and associated helpers
- Used new helpers in `Hellscape` to mark and remove retired events on each iteration